### PR TITLE
fix(CNavigation): Identify offsets for up and right vectors

### DIFF
--- a/CNavigation.hpp
+++ b/CNavigation.hpp
@@ -5,12 +5,12 @@ class CNavigation
 {
 public:
 	char pad_0000[32]; //0x0000
-	rage::fvector3 right; //0x0020
+	rage::fvector3 m_right; //0x0020
 	char pad_002C[4]; //0x002C
-	rage::fvector3 forward; //0x0030
+	rage::fvector3 m_forward; //0x0030
 	char pad_003C[4]; //0x003C
-	rage::fvector3 up; //0x0040
+	rage::fvector3 m_up; //0x0040
 	char pad_004C[4]; //0x004C
-	rage::fvector3 position; //0x0050
+	rage::fvector3 m_position; //0x0050
 }; //Size: 0x0060
 static_assert(sizeof(CNavigation) == 0x5C);

--- a/CNavigation.hpp
+++ b/CNavigation.hpp
@@ -5,11 +5,12 @@ class CNavigation
 {
 public:
 	char pad_0000[32]; //0x0000
-	float m_heading; //0x0020
-	float m_heading2; //0x0024
-	char pad_0028[8]; //0x0028
-	rage::fvector3 m_rotation; //0x0030
-	char pad_003C[20]; //0x003C
-	rage::fvector3 m_position; //0x0054
+	rage::fvector3 right; //0x0020
+	char pad_002C[4]; //0x002C
+	rage::fvector3 forward; //0x0030
+	char pad_003C[4]; //0x003C
+	rage::fvector3 up; //0x0040
+	char pad_004C[4]; //0x004C
+	rage::fvector3 position; //0x0050
 }; //Size: 0x0060
 static_assert(sizeof(CNavigation) == 0x5C);


### PR DESCRIPTION
The class is very similar to `CMatrix` from San Andreas.

https://github.com/Updated-Classic/gta-reversed-modern/blob/2e063063bed74690a4b6e9393f26f2b94ee4c1cb/source/game_sa/Core/Matrix.h