### PR TITLE
fix(Data Nodes): Two members in CPedTaskSpecificDataNode.

### DIFF
--- a/datanodes/ped/CPedTaskSpecificDataNode.hpp
+++ b/datanodes/ped/CPedTaskSpecificDataNode.hpp
@@ -6,7 +6,9 @@
 class CPedTaskSpecificDataNode
 {
 private:
-    char pad_0000[200]; //0x0000
+    char pad_0000[192]; //0x0000
+    uint32_t m_task_index; //0x00C0
+    uint32_t m_task_type; //0x00C4
     uint32_t m_buffer_size; //0x00C8
     uint8_t m_task_data_buffer[603]; //0x00CC
 }; //Size: 0x0328


### PR DESCRIPTION
Forgot two members, they weren't in the `NodeCommonDataOperations` reader, but were in the `IPedNodeDataAccessor`.