### PR TITLE
add atReferenceCounter

### DIFF
--- a/classes.cpp
+++ b/classes.cpp
@@ -139,6 +139,7 @@
 #include "player/CPlayerAngles.hpp"
 #include "player/CPlayerInfo.hpp"
 #include "rage/atArray.hpp"
+#include "rage/atReferenceCounter.hpp"
 #include "rage/atSingleton.hpp"
 #include "rage/joaat.hpp"
 #include "rage/rlGamerHandle.hpp"

--- a/rage/atReferenceCounter.hpp
+++ b/rage/atReferenceCounter.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../base/datBase.hpp"
+
+namespace rage
+{
+    class atReferenceCounter : public datBase
+    {
+    public:
+        atReferenceCounter() : m_ref_count(0) {}
+        
+        void AddReference() {
+            m_ref_count++;
+        }
+
+        void ReleaseReference() {
+            m_ref_count--;
+            if(m_ref_count == 0) {
+                delete this;
+            }
+        }
+
+        int GetReferenceCount() const {
+            return m_ref_count; 
+        }
+
+    private:
+        int m_ref_count;  // 0x0000
+    };
+}


### PR DESCRIPTION
when a new reference to an object is created, the counter is incremented by one, and when the reference is removed or changed to point to another object, the counter is decreased by one. When the counter becomes zero, it means that there are no longer active reviews of the object, so the object can be released and the resources associated with it can be restored.