### PR TITLE
resolve std::numeric_limits::max() windef.h:max(a, b) conflict in atArray implementations

### DIFF
--- a/rage/atArray.hpp
+++ b/rage/atArray.hpp
@@ -63,7 +63,7 @@ namespace rage
             auto value_array_size = value_array.size();
             auto old_capacity = m_count;
 
-            if ((value_array_size + m_count) > std::numeric_limits<uint16_t>::max())
+            if ((value_array_size + m_count) > (std::numeric_limits<uint16_t>::max)())
                 return false;
 
             auto size = (uint16_t)value_array_size;
@@ -84,7 +84,7 @@ namespace rage
             auto value_array_size = value_array.size();
             auto old_capacity = m_count;
 
-            if ((value_array_size + m_count) > std::numeric_limits<uint16_t>::max())
+            if ((value_array_size + m_count) > (std::numeric_limits<uint16_t>::max)())
                 return false;
 
             auto size = (uint16_t)value_array_size;
@@ -105,7 +105,7 @@ namespace rage
             auto value_array_size = value_array.size();
             auto old_capacity = m_count;
 
-            if ((value_array_size + m_count) > std::numeric_limits<uint16_t>::max())
+            if ((value_array_size + m_count) > (std::numeric_limits<uint16_t>::max)())
                 return false;
 
             auto size = (uint16_t)value_array_size;


### PR DESCRIPTION
There is a conflict in the atArray function implementations between std::numeric_limits::max() and the macro max(a, b) defined in windef.h (if NOMINMAX isnt present, see https://github.com/microsoft/cppwinrt/issues/479). By wrapping std::numeric_limits::max in parenthesis before calling it, the compiler explicitly uses the intended std::numeric_limits::max() function. In the c++/winrt issue it appears like this has been fixed, but even with a fully updated v143 toolset this issue persists.