### PR TITLE
fix(vector): Make vector operators and contructors `constexpr`.

### DIFF
--- a/rage/vector.hpp
+++ b/rage/vector.hpp
@@ -11,12 +11,12 @@ namespace rage
 			T x, y;
 		};
 
-		vector2(T x, T y) : x(x),
+		constexpr vector2(T x, T y) : x(x),
 							y(y)
 		{
 		}
 
-		vector2() : x(),
+		constexpr vector2() : x(),
 					y()
 		{
 		}
@@ -31,115 +31,115 @@ namespace rage
 			T x, y, z;
 		};
 
-		vector3(T x, T y, T z) noexcept : x(x),
+		constexpr vector3(T x, T y, T z) noexcept : x(x),
 										  y(y),
 										  z(z)
 		{
 		}
 
-		vector3() noexcept : x(),
+		constexpr vector3() noexcept : x(),
 							 y(),
 							 z()
 		{
 		}
 
-		vector3 operator+(const vector3 &rhs) const
+		constexpr vector3 operator+(const vector3 &rhs) const
 		{
 			return vector3(x + rhs.x, y + rhs.y, z + rhs.z);
 		}
 
-		vector3 operator-(const vector3 &rhs) const
+		constexpr vector3 operator-(const vector3 &rhs) const
 		{
 			return vector3(x - rhs.x, y - rhs.y, z - rhs.z);
 		}
 
-		vector3 operator*(const vector3 &rhs) const
+		constexpr vector3 operator*(const vector3 &rhs) const
 		{
 			return vector3(x * rhs.x, y * rhs.y, z * rhs.z);
 		}
 
-		vector3 operator/(const vector3 &rhs) const
+		constexpr vector3 operator/(const vector3 &rhs) const
 		{
 			return vector3(x / rhs.x, y / rhs.y, z / rhs.z);
 		}
 
-		vector3 operator+(const float &rhs) const
+		constexpr vector3 operator+(const float &rhs) const
 		{
 			return vector3(x + rhs, y + rhs, z + rhs);
 		}
 
-		vector3 operator-(const float &rhs) const
+		constexpr vector3 operator-(const float &rhs) const
 		{
 			return vector3(x - rhs, y - rhs, z - rhs);
 		}
 
-		vector3 operator*(const float &rhs) const
+		constexpr vector3 operator*(const float &rhs) const
 		{
 			return vector3(x * rhs, y * rhs, z * rhs);
 		}
 
-		vector3 operator/(const float &rhs) const
+		constexpr vector3 operator/(const float &rhs) const
 		{
 			return vector3(x / rhs, y / rhs, z / rhs);
 		}
 
-		bool operator==(const vector3 &rhs) const
+		constexpr bool operator==(const vector3 &rhs) const
 		{
 			return x == rhs.x && y == rhs.y && z == rhs.z;
 		}
 
-		vector3 &operator+=(const vector3 &rhs)
+		constexpr vector3 &operator+=(const vector3 &rhs)
 		{
 			return *this = *this + rhs;
 		}
 
-		vector3 &operator-=(const vector3 &rhs)
+		constexpr vector3 &operator-=(const vector3 &rhs)
 		{
 			return *this = *this - rhs;
 		}
 
-		vector3 &operator*=(const vector3 &rhs)
+		constexpr vector3 &operator*=(const vector3 &rhs)
 		{
 			return *this = *this * rhs;
 		}
 
-		vector3 &operator/=(const vector3 &rhs)
+		constexpr vector3 &operator/=(const vector3 &rhs)
 		{
 			return *this = *this / rhs;
 		}
 
-		vector3 &operator+=(const float &rhs)
+		constexpr vector3 &operator+=(const float &rhs)
 		{
 			return *this = *this + rhs;
 		}
 
-		vector3 &operator-=(const float &rhs)
+		constexpr vector3 &operator-=(const float &rhs)
 		{
 			return *this = *this - rhs;
 		}
 
-		vector3 &operator*=(const float &rhs)
+		constexpr vector3 &operator*=(const float &rhs)
 		{
 			return *this = *this * rhs;
 		}
 
-		vector3 &operator/=(const float &rhs)
+		constexpr vector3 &operator/=(const float &rhs)
 		{
 			return *this = *this / rhs;
 		}
 
-		T length() const
+		constexpr T length() const
 		{
 			return sqrt(x * x + y * y + z * z);
 		}
 
-		T magnitude() const
+		constexpr T magnitude() const
 		{
 			return length();
 		}
 
 		// This doesn't modify the vector inline.
-		vector3 normalize() const
+		constexpr vector3 normalize() const
 		{
 			T len = length();
 			if (len)
@@ -151,29 +151,29 @@ namespace rage
 		}
 
 		// This doesn't modify the vector inline.
-		vector3 multiply(const vector3 rhs) const
+		constexpr vector3 multiply(const vector3 rhs) const
 		{
 			return vector3(x * rhs.x, y * rhs.y, z * rhs.z);
 		}
 
 		// This doesn't modify the vector inline.
-		vector3 invert() const
+		constexpr vector3 invert() const
 		{
 			return *this * -1;
 		}
 
 		// This doesn't modify the vector inline.
-		vector3 cross_product(const vector3 &rhs) const
+		constexpr vector3 cross_product(const vector3 &rhs) const
 		{
 			return vector3(y * rhs.z - z * rhs.y, z * rhs.x - x * rhs.z, x * rhs.y - y * rhs.x);
 		}
 
-		float dot_product(const vector3 &rhs) const
+		constexpr float dot_product(const vector3 &rhs) const
 		{
 			return x * rhs.x + y * rhs.y + z * rhs.z;
 		}
 
-		float distance(const vector3 &rhs) const
+		constexpr float distance(const vector3 &rhs) const
 		{
 			return (*this - rhs).length();
 		}
@@ -188,14 +188,14 @@ namespace rage
 			T x, y, z, w;
 		};
 
-		vector4(T x, T y, T z, T w) : x(x),
+		constexpr vector4(T x, T y, T z, T w) : x(x),
 									  y(y),
 									  z(z),
 									  w(w)
 		{
 		}
 
-		vector4() : x(),
+		constexpr vector4() : x(),
 					y(),
 					z(),
 					w()


### PR DESCRIPTION
Clang refuses to compile YimMenu because `custom_call_context` can't be `constexpr`, because `rage::fvector4`'s constructor isn't `constexpr`.

This PR marks all vector functions as `constexpr`.

#### Related:
- #171
- YimMenu/YimMenu#3147

###### Maybe I should only mark the constructors as `constexpr`.