### PR TITLE
fix(MatchmakingId): Remove msvc extension.

### DIFF
--- a/network/MatchmakingId.hpp
+++ b/network/MatchmakingId.hpp
@@ -10,5 +10,5 @@ public:
 	std::uint64_t m_data2;
 	std::uint64_t m_data3;
 };
-static_assert(offsetof(MatchmakingId, MatchmakingId::m_data3) == 0x2E);
+static_assert(offsetof(MatchmakingId, m_data3) == 0x2E);
 #pragma pack(pop)


### PR DESCRIPTION
Allows `network/MatchmakingId.hpp` to compile on clang, gcc seems to support this extension.